### PR TITLE
Implement index-level generic support

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,12 @@ export type IndexConfig = {
 /**
  * Serverless vector client for upstash.
  */
-export class Index extends core.Index {
+export class Index<
+  TIndexMetadata extends Record<
+    string,
+    unknown
+  > = Record<string, unknown>
+> extends core.Index<TIndexMetadata> {
   /**
    * Create a new vector client by providing the url and token
    *

--- a/src/commands/client/fetch/index.ts
+++ b/src/commands/client/fetch/index.ts
@@ -9,7 +9,7 @@ type FetchCommandOptions = {
 export type FetchResult<TMetadata = Record<string, unknown>> = Vector<TMetadata> | null;
 
 export class FetchCommand<TMetadata> extends Command<FetchResult<TMetadata>[]> {
-  constructor([ids, opts]: [ids: number[] | string[], opts: FetchCommandOptions]) {
+  constructor([ids, opts]: [ids: number[] | string[], opts?: FetchCommandOptions]) {
     super({ ids, ...opts }, "fetch");
   }
 }

--- a/src/commands/client/upsert/index.ts
+++ b/src/commands/client/upsert/index.ts
@@ -1,13 +1,13 @@
 import { Command } from "@commands/command";
 
-type UpsertCommandPayload = {
+type UpsertCommandPayload<TMetadata> = {
   id: number | string;
   vector: number[];
-  metadata?: Record<string, unknown>;
+  metadata?: TMetadata;
 };
 
-export class UpsertCommand extends Command<string> {
-  constructor(payload: UpsertCommandPayload | UpsertCommandPayload[]) {
+export class UpsertCommand<TMetadata> extends Command<string> {
+  constructor(payload: UpsertCommandPayload<TMetadata> | UpsertCommandPayload<TMetadata>[]) {
     super(payload, "upsert");
   }
 }

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -15,8 +15,13 @@ export type CommandArgs<TCommand extends new (_args: any) => any> =
 /**
  * Serverless vector client for upstash vector db.
  */
-export class Index {
-  protected client: Requester;
+export class Index<
+  TIndexMetadata extends Record<
+    string,
+    unknown
+  > = Record<string, unknown>
+> {
+  protected client: Requester
 
   /**
    * Create a new vector db client
@@ -64,8 +69,14 @@ export class Index {
    *
    * @returns A promise that resolves with an array of query result objects when the request to query the index is completed.
    */
-  query = <TMetadata>(args: CommandArgs<typeof QueryCommand>) =>
-    new QueryCommand<TMetadata>(args).exec(this.client);
+  query = <
+    TMetadata extends TIndexMetadata = TIndexMetadata
+  >(
+    args: CommandArgs<typeof QueryCommand>
+  ) =>
+    new QueryCommand<TMetadata>(args).exec(
+      this.client
+    );
 
   /**
    * Upserts (Updates and Inserts) specific items into the index.
@@ -89,7 +100,11 @@ export class Index {
    *
    * @returns {string} A promise that resolves with the result of the upsert operation after the command is executed.
    */
-  upsert = (args: CommandArgs<typeof UpsertCommand>) => new UpsertCommand(args).exec(this.client);
+  upsert = <TMetadata extends TIndexMetadata = TIndexMetadata>(
+    args: CommandArgs<
+      typeof UpsertCommand<TMetadata>
+    >
+  ) => new UpsertCommand<TMetadata>(args).exec(this.client)
 
   /**
    * It's used for retrieving specific items from the index, optionally including
@@ -111,8 +126,12 @@ export class Index {
    *
    * @returns {Promise<FetchReturnResponse<TMetadata>[]>} A promise that resolves with an array of fetched items or null if not found, after the command is executed.
    */
-  fetch = <TMetadata>(...args: CommandArgs<typeof FetchCommand>) =>
-    new FetchCommand<TMetadata>(args).exec(this.client);
+  fetch = <TMetadata extends TIndexMetadata = TIndexMetadata>(
+    ...args: CommandArgs<typeof FetchCommand>
+  ) =>
+    new FetchCommand<TMetadata>(args).exec(
+      this.client
+    )
 
   /**
    * It's used for wiping an entire index.
@@ -150,8 +169,12 @@ export class Index {
    *
    * @returns {Promise<RangeReturnResponse<TMetadata>>} A promise that resolves with the response containing the next cursor and an array of vectors, after the command is executed.
    */
-  range = <TMetadata>(args: CommandArgs<typeof RangeCommand>) =>
-    new RangeCommand<TMetadata>(args).exec(this.client);
+  range = <TMetadata extends TIndexMetadata = TIndexMetadata>(
+    args: CommandArgs<typeof RangeCommand>
+  ) =>
+    new RangeCommand<TMetadata>(args).exec(
+      this.client
+    );
 
   /**
    * Retrieves info from the index.

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -15,13 +15,8 @@ export type CommandArgs<TCommand extends new (_args: any) => any> =
 /**
  * Serverless vector client for upstash vector db.
  */
-export class Index<
-  TIndexMetadata extends Record<
-    string,
-    unknown
-  > = Record<string, unknown>
-> {
-  protected client: Requester
+export class Index<TIndexMetadata extends Record<string, unknown> = Record<string, unknown>> {
+  protected client: Requester;
 
   /**
    * Create a new vector db client
@@ -69,14 +64,9 @@ export class Index<
    *
    * @returns A promise that resolves with an array of query result objects when the request to query the index is completed.
    */
-  query = <
-    TMetadata extends TIndexMetadata = TIndexMetadata
-  >(
+  query = <TMetadata extends TIndexMetadata = TIndexMetadata>(
     args: CommandArgs<typeof QueryCommand>
-  ) =>
-    new QueryCommand<TMetadata>(args).exec(
-      this.client
-    );
+  ) => new QueryCommand<TMetadata>(args).exec(this.client);
 
   /**
    * Upserts (Updates and Inserts) specific items into the index.
@@ -101,10 +91,8 @@ export class Index<
    * @returns {string} A promise that resolves with the result of the upsert operation after the command is executed.
    */
   upsert = <TMetadata extends TIndexMetadata = TIndexMetadata>(
-    args: CommandArgs<
-      typeof UpsertCommand<TMetadata>
-    >
-  ) => new UpsertCommand<TMetadata>(args).exec(this.client)
+    args: CommandArgs<typeof UpsertCommand<TMetadata>>
+  ) => new UpsertCommand<TMetadata>(args).exec(this.client);
 
   /**
    * It's used for retrieving specific items from the index, optionally including
@@ -128,10 +116,7 @@ export class Index<
    */
   fetch = <TMetadata extends TIndexMetadata = TIndexMetadata>(
     ...args: CommandArgs<typeof FetchCommand>
-  ) =>
-    new FetchCommand<TMetadata>(args).exec(
-      this.client
-    )
+  ) => new FetchCommand<TMetadata>(args).exec(this.client);
 
   /**
    * It's used for wiping an entire index.
@@ -171,10 +156,7 @@ export class Index<
    */
   range = <TMetadata extends TIndexMetadata = TIndexMetadata>(
     args: CommandArgs<typeof RangeCommand>
-  ) =>
-    new RangeCommand<TMetadata>(args).exec(
-      this.client
-    );
+  ) => new RangeCommand<TMetadata>(args).exec(this.client);
 
   /**
    * Retrieves info from the index.


### PR DESCRIPTION
This PR adds index-level generic support for strongly typed metadata across client commands and removes the redundant passing of options for the client command `fetch`.

To stay compliant with the implementation before and allow for flexible usage, each command also separately supports strongly typed metadata as opposed to defining it for the entire index.  

With these changes, a transition from existing providers like Pinecone is easier and the fetch api can be used more intuitively. 