### PR TITLE
DX-821: Add data as metadata

### DIFF
--- a/src/commands/client/upsert/index.test.ts
+++ b/src/commands/client/upsert/index.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { UpsertCommand, FetchCommand } from "@commands/index";
+import { FetchCommand, UpsertCommand } from "@commands/index";
 import { newHttpClient, resetIndexes } from "@utils/test-utils";
 
 const client = newHttpClient();
@@ -108,5 +108,5 @@ describe("UPSERT", () => {
     expect(resFetch[0]?.metadata).toEqual({ data: "testing data" });
 
     expect(resUpsert).toEqual("Success");
-  })
+  });
 });

--- a/src/commands/client/upsert/index.test.ts
+++ b/src/commands/client/upsert/index.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { UpsertCommand } from "@commands/index";
+import { UpsertCommand, FetchCommand } from "@commands/index";
 import { newHttpClient, resetIndexes } from "@utils/test-utils";
 
 const client = newHttpClient();
@@ -87,4 +87,26 @@ describe("UPSERT", () => {
 
     expect(throwable).toThrow();
   });
+
+  test("should add data as metadata, when no metadata is provided", async () => {
+    const embeddingClient = newHttpClient(undefined, {
+      token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
+      url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+    });
+    const resUpsert = await new UpsertCommand({
+      id: "hello-world",
+      data: "testing data",
+    }).exec(embeddingClient);
+
+    const resFetch = await new FetchCommand([
+      ["hello-world"],
+      {
+        includeMetadata: true,
+      },
+    ]).exec(embeddingClient);
+
+    expect(resFetch[0]?.metadata).toEqual({ data: "testing data" });
+
+    expect(resUpsert).toEqual("Success");
+  })
 });

--- a/src/commands/client/upsert/index.ts
+++ b/src/commands/client/upsert/index.ts
@@ -25,12 +25,28 @@ export class UpsertCommand<TMetadata> extends Command<string> {
       const hasData = payload.some((p) => "data" in p && p.data);
       if (hasData) {
         endpoint = "upsert-data";
+
+        for (const p of payload) {
+          if (!("metadata" in p) && "data" in p) {
+            p.metadata = {
+              data: p.data,
+            } as NoInfer<TMetadata & { data: string }>;
+          }
+        }
       }
     } else {
       if ("data" in payload) {
         endpoint = "upsert-data";
+
+        if (!("metadata" in payload)) {
+          payload.metadata = {
+            data: payload.data,
+          } as NoInfer<TMetadata & { data: string }>;
+        }
       }
     }
+
+
 
     super(payload, endpoint);
   }

--- a/src/commands/client/upsert/index.ts
+++ b/src/commands/client/upsert/index.ts
@@ -46,8 +46,6 @@ export class UpsertCommand<TMetadata> extends Command<string> {
       }
     }
 
-
-
     super(payload, endpoint);
   }
 }


### PR DESCRIPTION
This PR adds data as metadata, when no metadata is given for a embedding model upsert operation.