### PR TITLE
test: simplify tests by removing second vector for testing embeddings

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         run: bun run fmt
 
       - name: Run tests
-        run: bun run test
+        run: bun run test --timeout 20000
 
       - name: Run Build
         run: bun run build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         run: bun run fmt
 
       - name: Run tests
-        run: bun run test --timeout 20000
+        run: bun run test
 
       - name: Run Build
         run: bun run build

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "test": "bun test src --coverage --bail --coverageSkipTestFiles=[test-utils.ts] && vitest run --typecheck",
+    "test": "bun test src --coverage --bail --coverageSkipTestFiles=[test-utils.ts] --timeout 20000 && vitest run --typecheck",
     "fmt": "bunx biome check --apply ./src",
     "build": "tsup",
     "prepare": "husky install"

--- a/src/commands/client/delete/index.test.ts
+++ b/src/commands/client/delete/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { DeleteCommand, UpsertCommand } from "@commands/index";
-import { newHttpClient, randomID, resetIndexes } from "@utils/test-utils";
+import { newHttpClient, randomID, range, resetIndexes } from "@utils/test-utils";
 
 const client = newHttpClient();
 
@@ -8,7 +8,7 @@ describe("DELETE", () => {
   afterAll(async () => await resetIndexes());
 
   test("should delete record(s) successfully", async () => {
-    const initialVector = [6.6, 7.7];
+    const initialVector = range(0, 384);
     const idsToUpsert = [randomID(), randomID(), randomID()];
 
     const upsertPromises = idsToUpsert.map((id) =>
@@ -21,7 +21,7 @@ describe("DELETE", () => {
   });
 
   test("deleting the same ids should throw", async () => {
-    const initialVector = [6.6, 7.7];
+    const initialVector = range(0, 384);
     const idsToUpsert = [randomID(), randomID(), randomID()];
 
     const upsertPromises = idsToUpsert.map((id) =>
@@ -37,7 +37,7 @@ describe("DELETE", () => {
   });
 
   test("should delete single item", async () => {
-    const initialVector = [6.6, 7.7];
+    const initialVector = range(0, 384);
     const id = randomID();
     await new UpsertCommand({ id, vector: initialVector }).exec(client);
 

--- a/src/commands/client/fetch/index.test.ts
+++ b/src/commands/client/fetch/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { FetchCommand, UpsertCommand } from "@commands/index";
-import { newHttpClient, randomFloat, randomID, resetIndexes } from "@utils/test-utils";
+import { newHttpClient, randomID, range, resetIndexes } from "@utils/test-utils";
 
 const client = newHttpClient();
 
@@ -10,7 +10,7 @@ describe("FETCH", () => {
   test("should fetch records successfully", async () => {
     const randomizedData = new Array(20)
       .fill("")
-      .map(() => ({ id: randomID(), vector: [randomFloat(), randomFloat()] }));
+      .map(() => ({ id: randomID(), vector: range(0, 384) }));
 
     const payloads = randomizedData.map((data) => new UpsertCommand(data).exec(client));
     await Promise.all(payloads);
@@ -39,7 +39,7 @@ describe("FETCH", () => {
   test("should return with metadata", async () => {
     const mockData = {
       id: randomID(),
-      vector: [randomFloat(), randomFloat()],
+      vector: range(0, 384),
       metadata: { hello: "world" },
     };
     await new UpsertCommand(mockData).exec(client);

--- a/src/commands/client/info/index.test.ts
+++ b/src/commands/client/info/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { UpsertCommand } from "@commands/index";
-import { newHttpClient, randomFloat, randomID, resetIndexes } from "@utils/test-utils";
+import { newHttpClient, randomID, range, resetIndexes } from "@utils/test-utils";
 import { sleep } from "bun";
 import { InfoCommand } from ".";
 
@@ -13,7 +13,7 @@ describe("INFO", () => {
     const vectorCount = 20;
     const randomizedData = new Array(vectorCount).fill("").map(() => ({
       id: randomID(),
-      vector: [randomFloat(), randomFloat()],
+      vector: range(0, 384),
     }));
 
     const payloads = randomizedData.map((data) => new UpsertCommand(data).exec(client));

--- a/src/commands/client/range/index.test.ts
+++ b/src/commands/client/range/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { RangeCommand, UpsertCommand } from "@commands/index";
-import { newHttpClient, randomFloat, randomID, resetIndexes } from "@utils/test-utils";
+import { newHttpClient, randomID, range, resetIndexes } from "@utils/test-utils";
 
 const client = newHttpClient();
 
@@ -10,7 +10,7 @@ describe("RANGE", () => {
   test("should query records successfully", async () => {
     const randomizedData = new Array(20)
       .fill("")
-      .map(() => ({ id: randomID(), vector: [randomFloat(), randomFloat()] }));
+      .map(() => ({ id: randomID(), vector: range(0, 384) }));
 
     const payloads = randomizedData.map((data) => new UpsertCommand(data).exec(client));
     await Promise.all(payloads);

--- a/src/commands/client/reset/index.test.ts
+++ b/src/commands/client/reset/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { FetchCommand, ResetCommand, UpsertCommand } from "@commands/index";
-import { newHttpClient, randomFloat, randomID } from "@utils/test-utils";
+import { newHttpClient, randomID, range } from "@utils/test-utils";
 
 const client = newHttpClient();
 
@@ -8,7 +8,7 @@ describe("RESET", () => {
   test("should flush indexes successfully", async () => {
     const randomizedData = new Array(20)
       .fill("")
-      .map(() => ({ id: randomID(), vector: [randomFloat(), randomFloat()] }));
+      .map(() => ({ id: randomID(), vector: range(0, 384) }));
 
     const payloads = randomizedData.map((data) => new UpsertCommand(data).exec(client));
 

--- a/src/commands/client/upsert/index.test.ts
+++ b/src/commands/client/upsert/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { FetchCommand, UpsertCommand } from "@commands/index";
-import { newHttpClient, resetIndexes } from "@utils/test-utils";
+import { newHttpClient, range, resetIndexes } from "@utils/test-utils";
 
 const client = newHttpClient();
 
@@ -8,7 +8,7 @@ describe("UPSERT", () => {
   afterAll(async () => await resetIndexes());
 
   test("should add record successfully", async () => {
-    const res = await new UpsertCommand({ id: 1, vector: [0.1, 0.2] }).exec(client);
+    const res = await new UpsertCommand({ id: 1, vector: range(0, 384) }).exec(client);
     expect(res).toEqual("Success");
   });
 
@@ -25,7 +25,7 @@ describe("UPSERT", () => {
     //@ts-ignore
     const res = await new UpsertCommand({
       id: 1,
-      vector: [0.1, 0.2],
+      vector: range(0, 384),
       metadata: { upstash: "test" },
     }).exec(client);
     expect(res).toEqual("Success");
@@ -35,12 +35,12 @@ describe("UPSERT", () => {
     const res = await new UpsertCommand([
       {
         id: "hello-world",
-        vector: [0.1, 0.2],
+        vector: range(0, 384),
         metadata: { upstash: "test" },
       },
       {
         id: "hello-world-4",
-        vector: [3, 4],
+        vector: range(0, 384),
         metadata: { upstash: "test" },
       },
     ]).exec(client);

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -50,3 +50,11 @@ export function randomID(): string {
 export const randomFloat = () => parseFloat((Math.random() * 10).toFixed(1));
 
 export const resetIndexes = async () => await new ResetCommand().exec(newHttpClient());
+
+export const range = (start: number, end: number, step = 1) => {
+  const result = [];
+  for (let i = start; i < end; i += step) {
+    result.push(i);
+  }
+  return result;
+};


### PR DESCRIPTION
- Removed second vector db info to simplify tests. Right now vector-js only relies on single vector db to test every feature.