### PR TITLE
fix: cloudflare incompatibility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -116,7 +116,9 @@ export class Index<
       baseUrl: url,
       retry: configOrRequester?.retry,
       headers: { authorization: `Bearer ${token}` },
-      cache: configOrRequester?.cache || "no-store",
+      cache: configOrRequester?.cache === false 
+        ? undefined 
+        : configOrRequester?.cache || "no-store",
       signal: configOrRequester?.signal,
     });
 

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -6,7 +6,8 @@ type CacheSetting =
   | "no-cache"
   | "no-store"
   | "only-if-cached"
-  | "reload";
+  | "reload"
+  | false;
 
 export type UpstashRequest = {
   path?: string[];


### PR DESCRIPTION
Cloudflare does not currently support the cache header, leading to timeouts for requests containing it. With this PR you can explicitly disable caching for the cf runtime to use Upstash Vector as usual.