### PR TITLE
DX-914: Extend Tests with Index Client

### DIFF
--- a/src/commands/client/delete/index.test.ts
+++ b/src/commands/client/delete/index.test.ts
@@ -58,14 +58,17 @@ describe("DELETE with Index Client", () => {
     await index.reset();
   });
 
-  test("should delete single record succesfully", () => {
+  test("should delete single record succesfully", async () => {
     const initialVector = range(0, 384);
     const id = randomID();
 
     index.upsert({ id, vector: initialVector });
 
-    const deletionResult = index.delete(id);
-    expect(deletionResult).toBeTruthy();
+    const deletionResult = await index.delete(id);
+
+    expect(deletionResult).toEqual({
+      deleted: 1
+    });
   });
 
   test("should delete array of records successfully", async () => {
@@ -77,6 +80,8 @@ describe("DELETE with Index Client", () => {
     await Promise.all(upsertPromises);
 
     const deletionResult = await index.delete(idsToUpsert);
-    expect(deletionResult).toBeTruthy();
+    expect(deletionResult).toEqual({
+      deleted: 3,
+    })
   });
 });

--- a/src/commands/client/delete/index.test.ts
+++ b/src/commands/client/delete/index.test.ts
@@ -51,8 +51,11 @@ describe("DELETE", () => {
 
 describe("DELETE with Index Client", () => {
   const index = new Index({
-    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
-    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+    token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.UPSTASH_VECTOR_REST_URL!,
+  });
+  afterAll(async () => {
+    await index.reset();
   });
 
   test("should delete single record succesfully", () => {

--- a/src/commands/client/delete/index.test.ts
+++ b/src/commands/client/delete/index.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { DeleteCommand, UpsertCommand } from "@commands/index";
 import { newHttpClient, randomID, range, resetIndexes } from "@utils/test-utils";
+import { Index } from "@utils/test-utils";
 
 const client = newHttpClient();
 
@@ -45,5 +46,34 @@ describe("DELETE", () => {
     expect(res1).toEqual({
       deleted: 1,
     });
+  });
+});
+
+describe("DELETE with Index Client", () => {
+  const index = new Index({
+    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+  });
+
+  test("should delete single record succesfully", () => {
+    const initialVector = range(0, 384);
+    const id = randomID();
+
+    index.upsert({ id, vector: initialVector });
+
+    const deletionResult = index.delete(id);
+    expect(deletionResult).toBeTruthy();
+  });
+
+  test("should delete array of records successfully", async () => {
+    const initialVector = range(0, 384);
+    const idsToUpsert = [randomID(), randomID(), randomID()];
+
+    const upsertPromises = idsToUpsert.map((id) => index.upsert({ id, vector: initialVector }));
+
+    await Promise.all(upsertPromises);
+
+    const deletionResult = await index.delete(idsToUpsert);
+    expect(deletionResult).toBeTruthy();
   });
 });

--- a/src/commands/client/fetch/index.test.ts
+++ b/src/commands/client/fetch/index.test.ts
@@ -59,8 +59,8 @@ describe("FETCH", () => {
 
 describe("FETCH with Index Client", () => {
   const index = new Index({
-    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
-    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+    token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.UPSTASH_VECTOR_REST_URL!,
   });
 
   test("should fetch array of records by IDs succesfully", async () => {

--- a/src/commands/client/query/index.test.ts
+++ b/src/commands/client/query/index.test.ts
@@ -191,7 +191,6 @@ describe("QUERY", () => {
   );
 
   describe("with Index Client", () => {
-
     afterAll(async () => await resetIndexes());
 
     test("should query records successfully", async () => {
@@ -293,5 +292,3 @@ describe("QUERY", () => {
     });
   });
 });
-
-

--- a/src/commands/client/query/index.test.ts
+++ b/src/commands/client/query/index.test.ts
@@ -193,8 +193,6 @@ describe("QUERY", () => {
     },
     { timeout: 20000 }
   );
-
-
 });
 
 describe("with Index Client", () => {
@@ -221,7 +219,6 @@ describe("with Index Client", () => {
       vector: initialVector,
       topK: 1,
     });
-
 
     expect(res).toEqual([
       {

--- a/src/commands/client/query/index.test.ts
+++ b/src/commands/client/query/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { QueryCommand, UpsertCommand } from "@commands/index";
-import { awaitUntilIndexed, newHttpClient, randomID, range, resetIndexes } from "@utils/test-utils";
+import { awaitUntilIndexed, newHttpClient, randomID, range } from "@utils/test-utils";
 import { Index } from "@utils/test-utils";
 
 const client = newHttpClient();
@@ -15,7 +15,7 @@ describe("QUERY", () => {
     token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
     url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
   });
-  afterAll(async () => await resetIndexes());
+
   afterAll(async () => {
     await index.reset();
     await embeddingIndex.reset();
@@ -204,7 +204,11 @@ describe("with Index Client", () => {
     token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
     url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
   });
-  afterAll(async () => await resetIndexes());
+
+  afterAll(async () => {
+    await index.reset();
+    await embeddingIndex.reset();
+  });
 
   test("should query records successfully", async () => {
     const ID = randomID();
@@ -235,7 +239,7 @@ describe("with Index Client", () => {
       embeddingIndex.upsert([
         {
           id: "hello-world",
-          data: "testing-plan-text",
+          data: "with-index-plain-text-query-test",
           metadata: { upstash: "test" },
         },
       ]);
@@ -243,7 +247,7 @@ describe("with Index Client", () => {
       await awaitUntilIndexed(embeddingIndex);
 
       const res = await embeddingIndex.query({
-        data: "testing-plain-text",
+        data: "with-index-plain-text-query-test",
         topK: 1,
         includeVectors: true,
         includeMetadata: true,

--- a/src/commands/client/query/index.test.ts
+++ b/src/commands/client/query/index.test.ts
@@ -16,6 +16,10 @@ describe("QUERY", () => {
     url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
   });
   afterAll(async () => await resetIndexes());
+  afterAll(async () => {
+    await index.reset();
+    await embeddingIndex.reset();
+  });
   test("should query records successfully", async () => {
     const initialVector = range(0, 384);
     const initialData = { id: 33, vector: initialVector };

--- a/src/commands/client/query/index.test.ts
+++ b/src/commands/client/query/index.test.ts
@@ -6,6 +6,15 @@ import { Index } from "@utils/test-utils";
 const client = newHttpClient();
 
 describe("QUERY", () => {
+  const index = new Index({
+    token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.UPSTASH_VECTOR_REST_URL!,
+  });
+
+  const embeddingIndex = new Index({
+    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+  });
   afterAll(async () => await resetIndexes());
   test("should query records successfully", async () => {
     const initialVector = range(0, 384);
@@ -180,116 +189,109 @@ describe("QUERY", () => {
     },
     { timeout: 20000 }
   );
-});
 
-describe("QUERY with Index Client", () => {
-  const index = new Index({
-    token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
-    url: process.env.UPSTASH_VECTOR_REST_URL!,
-  });
+  describe("with Index Client", () => {
 
-  const embeddingIndex = new Index({
-    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
-    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
-  });
+    afterAll(async () => await resetIndexes());
 
-  afterAll(async () => await resetIndexes());
+    test("should query records successfully", async () => {
+      const ID = randomID();
+      const initialVector = range(0, 384);
+      const initialData = { id: ID, vector: initialVector };
+      await index.upsert(initialData);
 
-  test("should query records successfully", async () => {
-    const ID = randomID();
-    const initialVector = range(0, 384);
-    const initialData = { id: ID, vector: initialVector };
-    await index.upsert(initialData);
+      await awaitUntilIndexed(index);
 
-    await awaitUntilIndexed(index);
-
-    const res = await index.query<{ hello: "World" }>({
-      includeVectors: true,
-      vector: initialVector,
-      topK: 1,
-    });
-
-    expect(res).toEqual([
-      {
-        id: ID,
-        score: 1,
+      const res = await index.query<{ hello: "World" }>({
+        includeVectors: true,
         vector: initialVector,
-      },
-    ]);
-  });
+        topK: 1,
+      });
 
-  test(
-    "should query with plain text successfully",
-    async () => {
-      embeddingIndex.upsert([
+      expect(res).toEqual([
         {
-          id: "hello-world",
-          data: "testing-plan-text",
-          metadata: { upstash: "test" },
+          id: ID,
+          score: 1,
+          vector: initialVector,
         },
       ]);
+    });
 
-      await awaitUntilIndexed(embeddingIndex);
+    test(
+      "should query with plain text successfully",
+      async () => {
+        embeddingIndex.upsert([
+          {
+            id: "hello-world",
+            data: "testing-plan-text",
+            metadata: { upstash: "test" },
+          },
+        ]);
 
-      const res = await embeddingIndex.query({
-        data: "testing-plain-text",
+        await awaitUntilIndexed(embeddingIndex);
+
+        const res = await embeddingIndex.query({
+          data: "testing-plain-text",
+          topK: 1,
+          includeVectors: true,
+          includeMetadata: true,
+        });
+
+        expect(res[0].metadata).toEqual({ upstash: "test" });
+      },
+      { timeout: 20000 }
+    );
+
+    test("should narrow down the query results with filter", async () => {
+      const ID = randomID();
+      const initialVector = range(0, 384);
+      const initialData = [
+        {
+          id: `1-${ID}`,
+          vector: initialVector,
+          metadata: {
+            animal: "elephant",
+            tags: ["mammal"],
+            diet: "herbivore",
+          },
+        },
+        {
+          id: `2-${ID}`,
+          vector: initialVector,
+          metadata: {
+            animal: "tiger",
+            tags: ["mammal"],
+            diet: "carnivore",
+          },
+        },
+      ];
+
+      await index.upsert(initialData);
+
+      await awaitUntilIndexed(index);
+
+      const res = await index.query<{
+        animal: string;
+        tags: string[];
+        diet: string;
+      }>({
+        vector: initialVector,
         topK: 1,
+        filter: "tags[0] = 'mammal' AND diet = 'carnivore'",
         includeVectors: true,
         includeMetadata: true,
       });
 
-      expect(res[0].metadata).toEqual({ upstash: "test" });
-    },
-    { timeout: 20000 }
-  );
-
-  test("should narrow down the query results with filter", async () => {
-    const ID = randomID();
-    const initialVector = range(0, 384);
-    const initialData = [
-      {
-        id: `1-${ID}`,
-        vector: initialVector,
-        metadata: {
-          animal: "elephant",
-          tags: ["mammal"],
-          diet: "herbivore",
+      expect(res).toEqual([
+        {
+          id: `2-${ID}`,
+          score: 1,
+          vector: initialVector,
+          metadata: { animal: "tiger", tags: ["mammal"], diet: "carnivore" },
         },
-      },
-      {
-        id: `2-${ID}`,
-        vector: initialVector,
-        metadata: {
-          animal: "tiger",
-          tags: ["mammal"],
-          diet: "carnivore",
-        },
-      },
-    ];
-
-    await index.upsert(initialData);
-
-    await awaitUntilIndexed(index);
-
-    const res = await index.query<{
-      animal: string;
-      tags: string[];
-      diet: string;
-    }>({
-      vector: initialVector,
-      topK: 1,
-      filter: "tags[0] = 'mammal' AND diet = 'carnivore'",
-      includeVectors: true,
-      includeMetadata: true,
+      ]);
     });
-
-    expect(res).toEqual([
-      {
-        id: `2-${ID}`,
-        score: 1,
-        vector: initialVector,
-        metadata: { animal: "tiger", tags: ["mammal"], diet: "carnivore" },
-      },
-    ]);
   });
 });
+
+

--- a/src/commands/client/query/index.test.ts
+++ b/src/commands/client/query/index.test.ts
@@ -236,7 +236,7 @@ describe("with Index Client", () => {
   test(
     "should query with plain text successfully",
     async () => {
-      embeddingIndex.upsert([
+      await embeddingIndex.upsert([
         {
           id: "hello-world",
           data: "with-index-plain-text-query-test",

--- a/src/commands/client/range/index.test.ts
+++ b/src/commands/client/range/index.test.ts
@@ -1,6 +1,13 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { RangeCommand, UpsertCommand } from "@commands/index";
-import { newHttpClient, randomID, range, resetIndexes } from "@utils/test-utils";
+import {
+  Index,
+  awaitUntilIndexed,
+  newHttpClient,
+  randomID,
+  range,
+  resetIndexes,
+} from "@utils/test-utils";
 
 const client = newHttpClient();
 
@@ -15,11 +22,39 @@ describe("RANGE", () => {
     const payloads = randomizedData.map((data) => new UpsertCommand(data).exec(client));
     await Promise.all(payloads);
 
+    await awaitUntilIndexed(client);
+
     const res = await new RangeCommand({
       cursor: 0,
       limit: 5,
       includeVectors: true,
     }).exec(client);
+    expect(res.nextCursor).toBe("5");
+  });
+});
+
+describe("RANGE with Index Client", () => {
+  const index = new Index({
+    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+  });
+
+  afterAll(async () => await resetIndexes());
+  test("should query records successfully", async () => {
+    const randomizedData = new Array(20)
+      .fill("")
+      .map(() => ({ id: randomID(), vector: range(0, 384) }));
+
+    await index.upsert(randomizedData);
+
+    await awaitUntilIndexed(index);
+
+    const res = await index.range({
+      cursor: 0,
+      limit: 5,
+      includeVectors: true,
+    });
+
     expect(res.nextCursor).toBe("5");
   });
 });

--- a/src/commands/client/range/index.test.ts
+++ b/src/commands/client/range/index.test.ts
@@ -14,7 +14,7 @@ const client = newHttpClient();
 describe("RANGE", () => {
   afterAll(async () => await resetIndexes());
 
-  test("should query records successfully", async () => {
+  test("should paginate records successfully", async () => {
     const randomizedData = new Array(20)
       .fill("")
       .map(() => ({ id: randomID(), vector: range(0, 384) }));
@@ -42,7 +42,7 @@ describe("RANGE with Index Client", () => {
   afterAll(async () => {
     await index.reset();
   });
-  test("should query records successfully", async () => {
+  test("should paginate records successfully", async () => {
     const randomizedData = new Array(20)
       .fill("")
       .map(() => ({ id: randomID(), vector: range(0, 384) }));

--- a/src/commands/client/range/index.test.ts
+++ b/src/commands/client/range/index.test.ts
@@ -35,11 +35,13 @@ describe("RANGE", () => {
 
 describe("RANGE with Index Client", () => {
   const index = new Index({
-    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
-    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+    token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.UPSTASH_VECTOR_REST_URL!,
   });
 
-  afterAll(async () => await resetIndexes());
+  afterAll(async () => {
+    await index.reset();
+  });
   test("should query records successfully", async () => {
     const randomizedData = new Array(20)
       .fill("")

--- a/src/commands/client/reset/index.test.ts
+++ b/src/commands/client/reset/index.test.ts
@@ -23,6 +23,7 @@ describe("RESET", () => {
 
     expect(res).toEqual(randomizedData);
 
+
     await new ResetCommand().exec(client);
     const resAfterReset = await new FetchCommand([
       randomizedData.map((x) => x.id),

--- a/src/commands/client/reset/index.test.ts
+++ b/src/commands/client/reset/index.test.ts
@@ -23,7 +23,6 @@ describe("RESET", () => {
 
     expect(res).toEqual(randomizedData);
 
-
     await new ResetCommand().exec(client);
     const resAfterReset = await new FetchCommand([
       randomizedData.map((x) => x.id),

--- a/src/commands/client/update/index.test.ts
+++ b/src/commands/client/update/index.test.ts
@@ -34,10 +34,12 @@ describe("UPDATE", () => {
 
 describe("UPDATE with Index Client", () => {
   const index = new Index({
-    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
-    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+    token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.UPSTASH_VECTOR_REST_URL!,
   });
-  afterAll(async () => await resetIndexes());
+  afterAll(async () => {
+    await index.reset();
+  });
 
   test("should update vector metadata", async () => {
     await index.upsert({

--- a/src/commands/client/update/index.test.ts
+++ b/src/commands/client/update/index.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { FetchCommand, UpdateCommand, UpsertCommand } from "@commands/index";
-import { awaitUntilIndexed, newHttpClient, range, resetIndexes } from "@utils/test-utils";
+import { Index, awaitUntilIndexed, newHttpClient, range, resetIndexes } from "@utils/test-utils";
 
 const client = newHttpClient();
 
@@ -27,6 +27,37 @@ describe("UPDATE", () => {
       ["1"],
       { includeMetadata: true },
     ]).exec(client);
+
+    expect(fetchData[0]?.metadata?.upstash).toBe("test-update");
+  });
+});
+
+describe("UPDATE with Index Client", () => {
+  const index = new Index({
+    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+  });
+  afterAll(async () => await resetIndexes());
+
+  test("should update vector metadata", async () => {
+    await index.upsert({
+      id: 1,
+      vector: range(0, 384),
+      metadata: { upstash: "test-simple" },
+    });
+
+    await awaitUntilIndexed(index);
+
+    const res = await index.update({
+      id: 1,
+      metadata: { upstash: "test-update" },
+    });
+
+    expect(res).toEqual({ updated: 1 });
+
+    await awaitUntilIndexed(client, 5000);
+
+    const fetchData = await index.fetch(["1"], { includeMetadata: true });
 
     expect(fetchData[0]?.metadata?.upstash).toBe("test-update");
   });

--- a/src/commands/client/upsert/index.test.ts
+++ b/src/commands/client/upsert/index.test.ts
@@ -1,15 +1,10 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { FetchCommand, UpsertCommand } from "@commands/index";
-import { newHttpClient, randomID, range, resetIndexes } from "@utils/test-utils";
-import { Index } from "../../../../index";
+import { Index, newHttpClient, randomID, range, resetIndexes } from "@utils/test-utils";
 
 const client = newHttpClient();
 
 describe("UPSERT", () => {
-  const index = new Index({
-    url: process.env.UPSTASH_VECTOR_REST_URL!,
-    token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
-  });
   afterAll(async () => await resetIndexes());
 
   test("should add record successfully", async () => {
@@ -115,6 +110,38 @@ describe("UPSERT", () => {
 
     expect(resUpsert).toEqual("Success");
   });
+});
+
+describe("UPSERT with Index Client", () => {
+  const index = new Index({
+    token: process.env.EMBEDDING_UPSTASH_VECTOR_REST_TOKEN!,
+    url: process.env.EMBEDDING_UPSTASH_VECTOR_REST_URL!,
+  });
+  afterAll(async () => await resetIndexes());
+
+  test("should add record successfully", async () => {
+    const res = await index.upsert({ id: 1, vector: range(0, 384) });
+    expect(res).toEqual("Success");
+  });
+
+  // biome-ignore lint/nursery/useAwait: required to test bad payloads
+  test("should return an error when vector is missing", async () => {
+    const throwable = async () => {
+      //@ts-ignore
+      await new UpsertCommand({ id: 1 }).exec(client);
+    };
+    expect(throwable).toThrow();
+  });
+
+  test("should add data successfully with a metadata", async () => {
+    //@ts-ignore
+    const res = await new UpsertCommand({
+      id: 1,
+      vector: range(0, 384),
+      metadata: { upstash: "test" },
+    }).exec(client);
+    expect(res).toEqual("Success");
+  });
 
   test("should run with index.upsert in bulk", async () => {
     const upsertData = [
@@ -132,5 +159,37 @@ describe("UPSERT", () => {
     const resUpsert = await index.upsert(upsertData, { namespace: "test-namespace" });
 
     expect(resUpsert).toEqual("Success");
+  });
+
+  test("should add plain text as data successfully", async () => {
+    const res = await index.upsert([
+      {
+        id: "hello-world",
+        data: "Test1-2-3-4-5",
+        metadata: { upstash: "test" },
+      },
+    ]);
+    expect(res).toEqual("Success");
+  });
+
+  test("should fail to upsert due to mixed usage of vector and plain text", () => {
+    const throwable = async () => {
+      await index.upsert([
+        {
+          id: "hello-world",
+
+          data: "Test1-2-3-4-5",
+          metadata: { upstash: "test" },
+        },
+        {
+          id: "hello-world",
+          //@ts-expect-error Mixed usage of vector and data in the same upsert command is not allowed.
+          vector: [1, 2, 3, 4],
+          metadata: { upstash: "test" },
+        },
+      ]);
+    };
+
+    expect(throwable).toThrow();
   });
 });

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -58,10 +58,13 @@ export const resetIndexes = async () => await new ResetCommand().exec(newHttpCli
 export const range = (start: number, end: number, step = 1) => {
   const result = [];
   for (let i = start; i < end; i += step) {
-    result.push(i);
+    const randomNum = Math.floor(Math.random() * (end - start + 1)) + start;
+    result.push(randomNum);
   }
   return result;
 };
+
+
 
 export const awaitUntilIndexed = async (client: HttpClient | Index, timeoutMillis = 10_000) => {
   const start = performance.now();

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -64,8 +64,6 @@ export const range = (start: number, end: number, step = 1) => {
   return result;
 };
 
-
-
 export const awaitUntilIndexed = async (client: HttpClient | Index, timeoutMillis = 10_000) => {
   const start = performance.now();
 

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -3,6 +3,7 @@ import { InfoCommand } from "../commands/client/info";
 import { ResetCommand } from "../commands/client/reset";
 import { HttpClient, RetryConfig } from "../http";
 import { Index } from "../vector";
+export * from "../../index";
 
 export type NonArrayType<T> = T extends Array<infer U> ? U : T;
 

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -58,7 +58,7 @@ export const resetIndexes = async () => await new ResetCommand().exec(newHttpCli
 export const range = (start: number, end: number, step = 1) => {
   const result = [];
   for (let i = start; i < end; i += step) {
-    result.push(i);
+    result.push(Math.random());
   }
   return result;
 };

--- a/src/utils/test-utils.ts
+++ b/src/utils/test-utils.ts
@@ -58,7 +58,7 @@ export const resetIndexes = async () => await new ResetCommand().exec(newHttpCli
 export const range = (start: number, end: number, step = 1) => {
   const result = [];
   for (let i = start; i < end; i += step) {
-    result.push(Math.random());
+    result.push(i);
   }
   return result;
 };


### PR DESCRIPTION
This PR adds the necessary tests for the index client. Instead of only testing the internal commands, we now also test them with the actual client to make sure we don't break anything in the public interface.