### PR TITLE
feat: add data field to upsert, query and fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const index = new Index<Metadata>({
   token: "<UPSTASH_VECTOR_REST_TOKEN>",
 });
 
-//Upsert Data
+//Upsert data
 await index.upsert([{
   id: 'upstash-rocks',
   vector: [
@@ -60,17 +60,21 @@ await index.upsert([{
   }
 }])
 
-// Upsert Data as Plain Text. 
-// This data will be directly converted into embeddings.
+// Upsert data as plain text.
 await index.upsert([{
   id: 'tokyo',
   data: "Tokyo is the capital of Japan.",
-  metadata: {
-    text: 'Tokyo is the capital of Japan.'
-  }
 }])
 
-//Query Data
+//Upsert data alongside with your embedding
+await index.upsert([{
+  id: 'tokyo',
+  data: "Tokyo is the capital of Japan.",
+  vector: [......]
+}])
+
+
+//Query data
 const results = await index.query<Metadata>(
   {
     vector: [
@@ -86,9 +90,28 @@ const results = await index.query<Metadata>(
   }
 )
 
+//Query with your data
+const results = await index.query(
+  {
+    data: "Where is the capital of Japan",
+    topK: 1,
+  },
+)
+
+//Query with your data
+const results = await index.query(
+  {
+    vector: [
+      ... // query embedding
+    ],
+    includeData: true, // Returns data associated with your vector.
+    topK: 1,
+  },
+)
+
 // If you wanna learn more about filtering check: [Metadata Filtering](https://upstash.com/docs/vector/features/filtering)
 
-//Update Data
+//Update data
 await index.upsert(
   {
     id: "upstash-rocks",
@@ -111,6 +134,9 @@ await index.delete(["id-1", "id-2", "id-3"]);
 
 //Fetch records by their IDs
 await index.fetch(["id-1", "id-2"], {namespace: "example-namespace"});
+
+//Fetch records by their IDs
+await index.fetch(["id-1", "id-2"], {namespace: "example-namespace", includeData:true});
 
 //Fetch records with range
 await index.range(
@@ -233,11 +259,7 @@ Make sure you have Bun.js installed and have those relevant keys with specific v
 
 ```bash
 
-## Vector dimension should be 2
+## Vector dimension should be 3842
 UPSTASH_VECTOR_REST_URL="XXXXX"
 UPSTASH_VECTOR_REST_TOKEN="XXXXX"
-
-## Vector dimension should be 384
-EMBEDDING_UPSTASH_VECTOR_REST_URL="XXXXX"
-EMBEDDING_UPSTASH_VECTOR_REST_TOKEN="XXXXX"
 ```

--- a/src/commands/client/fetch/index.ts
+++ b/src/commands/client/fetch/index.ts
@@ -5,6 +5,7 @@ import { Command } from "@commands/command";
 type FetchCommandOptions = {
   includeMetadata?: boolean;
   includeVectors?: boolean;
+  includeData?: boolean;
   namespace?: string;
 };
 

--- a/src/commands/client/query/index.ts
+++ b/src/commands/client/query/index.ts
@@ -7,13 +7,15 @@ type QueryCommandPayload = {
   filter?: string;
   includeVectors?: boolean;
   includeMetadata?: boolean;
+  includeData?: boolean;
 } & ({ vector: number[]; data?: never } | { data: string; vector?: never });
 
 export type QueryResult<TMetadata = Dict> = {
   id: number | string;
   score: number;
-  vector: number[];
+  vector?: number[];
   metadata?: TMetadata;
+  data?: string;
 };
 
 type QueryCommandOptions = { namespace?: string };

--- a/src/commands/client/reset/index.test.ts
+++ b/src/commands/client/reset/index.test.ts
@@ -1,36 +1,41 @@
 import { describe, expect, test } from "bun:test";
 import { FetchCommand, ResetCommand, UpsertCommand } from "@commands/index";
-import { newHttpClient, randomID, range } from "@utils/test-utils";
+import { awaitUntilIndexed, newHttpClient, randomID, range } from "@utils/test-utils";
 
 const client = newHttpClient();
 
 describe("RESET", () => {
-  test("should flush indexes successfully", async () => {
-    const randomizedData = new Array(20)
-      .fill("")
-      .map(() => ({ id: randomID(), vector: range(0, 384) }));
+  test(
+    "should flush indexes successfully",
+    async () => {
+      const randomizedData = new Array(20)
+        .fill("")
+        .map(() => ({ id: randomID(), vector: range(0, 384) }));
 
-    const payloads = randomizedData.map((data) => new UpsertCommand(data).exec(client));
+      await new UpsertCommand(randomizedData).exec(client);
+      await awaitUntilIndexed(client);
 
-    await Promise.all(payloads);
+      const res = await new FetchCommand([
+        randomizedData.map((x) => x.id),
+        {
+          includeVectors: true,
+        },
+      ]).exec(client);
 
-    const res = await new FetchCommand([
-      randomizedData.map((x) => x.id),
-      {
-        includeVectors: true,
-      },
-    ]).exec(client);
+      expect(res).toEqual(randomizedData);
 
-    expect(res).toEqual(randomizedData);
+      await new ResetCommand().exec(client);
+      await awaitUntilIndexed(client);
 
-    await new ResetCommand().exec(client);
-    const resAfterReset = await new FetchCommand([
-      randomizedData.map((x) => x.id),
-      {
-        includeVectors: true,
-      },
-    ]).exec(client);
+      const resAfterReset = await new FetchCommand([
+        randomizedData.map((x) => x.id),
+        {
+          includeVectors: true,
+        },
+      ]).exec(client);
 
-    expect(resAfterReset).toEqual(new Array(20).fill(null));
-  });
+      expect(resAfterReset).toEqual(new Array(20).fill(null));
+    },
+    { timeout: 30000 }
+  );
 });

--- a/src/commands/client/types.ts
+++ b/src/commands/client/types.ts
@@ -1,7 +1,8 @@
 export type Vector<TMetadata = Dict> = {
   id: string;
-  vector: number[];
+  vector?: number[];
   metadata?: TMetadata;
+  data?: string;
 };
 
 export type NAMESPACE = string;

--- a/src/commands/client/upsert/index.ts
+++ b/src/commands/client/upsert/index.ts
@@ -34,34 +34,21 @@ export class UpsertCommand<TMetadata> extends Command<string> {
     let endpoint: UpsertEndpointVariants = "upsert";
 
     if (Array.isArray(payload)) {
-      const hasData = payload.some((p) => "data" in p && p.data);
-      if (hasData) {
-        endpoint = "upsert-data";
-
-        for (const p of payload) {
-          if (!("metadata" in p) && "data" in p) {
-            p.metadata = {
-              data: p.data,
-            } as NoInfer<TMetadata & { data: string }>;
-          }
-        }
-      }
+      const isUpsert = payload.some((p) => isVectorPayload(p));
+      endpoint = isUpsert ? "upsert" : "upsert-data";
     } else {
-      if ("data" in payload) {
-        endpoint = "upsert-data";
-
-        if (!("metadata" in payload)) {
-          payload.metadata = {
-            data: payload.data,
-          } as NoInfer<TMetadata & { data: string }>;
-        }
-      }
+      endpoint = isVectorPayload(payload) ? "upsert" : "upsert-data";
     }
 
     if (opts?.namespace) {
       endpoint = `${endpoint}/${opts.namespace}`;
     }
-
     super(payload, endpoint);
   }
 }
+
+const isVectorPayload = <TMetadata>(
+  payload: VectorPayload<TMetadata> | DataPayload<TMetadata>
+): payload is VectorPayload<TMetadata> => {
+  return "vector" in payload;
+};

--- a/src/http/index.test.ts
+++ b/src/http/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { newHttpClient } from "@utils/test-utils";
 import { HttpClient } from "./";
 
@@ -50,42 +50,5 @@ describe("Abort", () => {
     controller.abort("Abort works!");
 
     expect((await body).result).toEqual("Abort works!");
-  });
-});
-
-describe("Test retry", () => {
-  let originalFetch: typeof global.fetch;
-  let fetchCallCount: number;
-
-  beforeEach(() => {
-    originalFetch = global.fetch;
-    fetchCallCount = 0;
-  });
-
-  afterEach(() => {
-    // Restore the original fetch after each test
-    global.fetch = originalFetch;
-  });
-
-  function mockFetchToFailTwiceThenSucceed() {
-    global.fetch = mock(() => {
-      fetchCallCount += 1;
-      if (fetchCallCount <= 2) {
-        return Promise.reject(new Error("Network failure"));
-      }
-      return Promise.resolve(new Response(JSON.stringify({ data: "success" })));
-    });
-  }
-
-  test("retry logic on network failure", async () => {
-    mockFetchToFailTwiceThenSucceed();
-
-    const client = newHttpClient({ retries: 3 });
-
-    try {
-      await client.request({ path: ["test"] });
-    } catch {}
-
-    expect(global.fetch).toHaveBeenCalledTimes(3); // Check if fetch was called 3 times
   });
 });


### PR DESCRIPTION
This PR:

- Fixes flakys some of the flaky tests
- Adds `data`field support to upsert, data and fetch commands
- Updates readme
- Removes old automatic metadata insertion logic.
