### PR TITLE
feat: add includeData support to range

### DIFF
--- a/src/commands/client/fetch/index.test.ts
+++ b/src/commands/client/fetch/index.test.ts
@@ -64,6 +64,7 @@ describe("FETCH", () => {
 });
 
 describe("FETCH with Index Client", () => {
+  afterAll(async () => await resetIndexes());
   const index = new Index({
     token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
     url: process.env.UPSTASH_VECTOR_REST_URL!,

--- a/src/commands/client/range/index.test.ts
+++ b/src/commands/client/range/index.test.ts
@@ -17,7 +17,7 @@ describe("RANGE", () => {
   test("should paginate records successfully", async () => {
     const randomizedData = new Array(20)
       .fill("")
-      .map(() => ({ id: randomID(), vector: range(0, 384) }));
+      .map(() => ({ id: randomID(), data: "Test data" }));
 
     const payloads = randomizedData.map((data) => new UpsertCommand(data).exec(client));
     await Promise.all(payloads);
@@ -27,9 +27,9 @@ describe("RANGE", () => {
     const res = await new RangeCommand({
       cursor: 0,
       limit: 5,
-      includeVectors: true,
+      includeData: true,
     }).exec(client);
-    expect(res.nextCursor).toBe("5");
+    expect(res.vectors[0].data).toEqual("Test data");
   });
 });
 

--- a/src/commands/client/range/index.ts
+++ b/src/commands/client/range/index.ts
@@ -7,6 +7,7 @@ type RangeCommandPayload = {
   limit: number;
   includeVectors?: boolean;
   includeMetadata?: boolean;
+  includeData?: boolean;
 };
 
 type RangeCommandOptions = { namespace?: string };

--- a/src/commands/client/upsert/index.test.ts
+++ b/src/commands/client/upsert/index.test.ts
@@ -172,6 +172,7 @@ describe("UPSERT with Index Client", () => {
 });
 
 describe("Upsert with new data field", () => {
+  afterAll(async () => await resetIndexes());
   test("should add data to data field - /upsert-data", async () => {
     const id = randomID();
     const data = "testing data";


### PR DESCRIPTION
This PR adds:

- Missing resets
- includeData support to `range`