### PR TITLE
Add cloudflare/nodejs imports and add cache parameter to cloudflare client

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,14 @@
         "import": "./dist/cloudflare.mjs",
         "types": "./dist/cloudflare.d.ts"
       }
+    },
+    "./cloudflare": {
+      "import": "./dist/cloudflare.mjs",
+      "types": "./dist/cloudflare.d.ts"
+    },
+    "./nodejs": {
+      "import": "./dist/nodejs.mjs",
+      "types": "./dist/nodejs.d.ts"
     }
   },
   "main": "./dist/nodejs.js",

--- a/src/platforms/cloudflare.ts
+++ b/src/platforms/cloudflare.ts
@@ -76,6 +76,7 @@ export class Index<TIndexMetadata extends Dict = Dict> extends core.Index<TIndex
       retry: config?.retry,
       headers: { authorization: `Bearer ${token}` },
       signal: config?.signal,
+      cache: config?.cache === false ? undefined : config?.cache,
     });
 
     super(client);


### PR DESCRIPTION
added the imports because we could use explicit import when debugging.

added cache field because by default it's undefined and won't cause an issue if not passed in cloudflare workers. We will be able to explicitly set it if needed.

Comparison between nodejs and cloudflare:
```ts
// nodejs
cache: configOrRequester?.cache === false ? undefined : configOrRequester?.cache || "no-store",

// cloudflare
cache: config?.cache === false ? undefined : config?.cache,
```