### PR TITLE
DX-1264: Unify exports

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Publish release candidate
         if: "github.event.release.prerelease"
-        run: npm publish --access public --tag=canary --no-git-checks
+        run: npm publish --access public --tag=canary
 
       - name: Publish
         if: "!github.event.release.prerelease"
-        run: npm publish --access public --no-git-checks
+        run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -9,37 +9,19 @@
   "exports": {
     ".": {
       "import": "./dist/nodejs.mjs",
-      "require": "./dist/nodejs.js",
-      "types": "./dist/nodejs.d.ts",
-      "browser": "./dist/nodejs.mjs",
-      "bun": "./dist/nodejs.mjs",
-      "deno": "./dist/nodejs.mjs",
-      "edge-light": "./dist/nodejs.mjs",
-      "edge-routine": "./dist/nodejs.mjs",
-      "netlify": "./dist/nodejs.mjs",
-      "react-native": "./dist/nodejs.mjs",
-      "wintercg": "./dist/nodejs.mjs",
-      "worker": {
-        "import": "./dist/cloudflare.mjs",
-        "types": "./dist/cloudflare.d.ts"
-      },
-      "workerd": {
-        "import": "./dist/cloudflare.mjs",
-        "types": "./dist/cloudflare.d.ts"
-      }
+      "require": "./dist/nodejs.js"
     },
     "./cloudflare": {
       "import": "./dist/cloudflare.mjs",
-      "types": "./dist/cloudflare.d.ts"
+      "require": "./dist/cloudflare.js"
     },
     "./nodejs": {
       "import": "./dist/nodejs.mjs",
-      "types": "./dist/nodejs.d.ts"
+      "require": "./dist/nodejs.js"
     }
   },
   "main": "./dist/nodejs.js",
   "module": "./dist/nodejs.mjs",
-  "browser": "./dist/nodejs.mjs",
   "types": "./dist/nodejs.d.ts",
   "devDependencies": {
     "@commitlint/cli": "^18.6.0",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,8 +3,6 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["./src/platforms/nodejs.ts", "./src/platforms/cloudflare.ts"],
   format: ["cjs", "esm"],
-  sourcemap: false,
   clean: true,
   dts: true,
-  minify: true,
 });


### PR DESCRIPTION
This PR introduces some small tweaks to unify some parts of our javascript packages. Here are the changes:

- Updated tsup config
- Remove unnecessary flag from ci
- Updated exports field in package.json

I removed all the custom platform exports because they were never used. Since there are "import" and "require" fields, when an import is happening, all other fields are ignored.
```
 ".": {
      "import": "./dist/nodejs.mjs",
      "require": "./dist/nodejs.js",
      "types": "./dist/nodejs.d.ts",
      ...
}

Here is the before and after output coming from the attw cli:
```
<img width="851" alt="v before" src="https://github.com/user-attachments/assets/1a8825d0-c1df-49f6-8d2b-faa94ba22ff3">
<img width="860" alt="v after" src="https://github.com/user-attachments/assets/14835fe4-c5fe-44e5-8e22-92790a01eb50">

