### PR TITLE
DX-1624: namespace.resumableQuery command

### DIFF
--- a/src/commands/client/namespace/index.test.ts
+++ b/src/commands/client/namespace/index.test.ts
@@ -105,4 +105,72 @@ describe("NAMESPACE", () => {
 
     expect(fetchData[0]?.metadata?.upstash).toBe("test-1-updated");
   });
+
+  describe("RESUMABLE QUERY", () => {
+    afterAll(async () => await resetIndexes());
+
+    const index = new Index({
+      url: process.env.UPSTASH_VECTOR_REST_URL!,
+      token: process.env.UPSTASH_VECTOR_REST_TOKEN!,
+    });
+
+    test("should fetch results in batches from namespace", async () => {
+      const namespace = index.namespace("test-namespace-resumable");
+
+      await namespace.upsert([
+        { id: 1, vector: range(0, 384) },
+        { id: 2, vector: range(0, 384) },
+        { id: 3, vector: range(0, 384) },
+      ]);
+
+      await awaitUntilIndexed(index);
+
+      const { result, fetchNext, stop } = await namespace.resumableQuery({
+        maxIdle: 3600,
+        topK: 2,
+        vector: range(0, 384),
+        includeMetadata: true,
+      });
+
+      expect(result).toBeDefined();
+      expect(result.length).toBe(2);
+
+      const nextBatch = await fetchNext(1);
+      expect(nextBatch).toBeDefined();
+      expect(nextBatch.length).toBe(1);
+
+      await stop();
+    }, 10_000);
+
+    test("should throw error after stopping query", async () => {
+      const namespace = index.namespace("test-namespace-resumable-stop");
+
+      await namespace.upsert({
+        id: "test",
+        vector: range(0, 384),
+      });
+
+      await awaitUntilIndexed(index);
+
+      const query = await namespace.resumableQuery({
+        maxIdle: 3600,
+        topK: 10,
+        vector: range(0, 384),
+      });
+
+      expect(query.result).toBeDefined();
+      await query.stop();
+
+      try {
+        await query.fetchNext(5);
+        expect(false).toBe(true); // Force failure if no error thrown
+      } catch (error) {
+        if (error instanceof Error)
+          expect(error.message).toBe(
+            "The resumable query has already been stopped. Please start another resumable query."
+          );
+      }
+    });
+  });
 });
+


### PR DESCRIPTION
This PR adds the missing resumable query command for namespaces, where the usage is

```typescript
      const query = await index.namespace("ns").resumableQuery({
        maxIdle: 3600,
        topK: 10,
        vector: range(0, 384),
      });
```