### PR TITLE
DX-1639: Update Info Response

### DIFF
--- a/src/commands/client/info/index.ts
+++ b/src/commands/client/info/index.ts
@@ -1,17 +1,30 @@
 import { Command } from "@commands/command";
 
 type NamespaceTitle = string;
+type SimilarityFunction = "COSINE" | "EUCLIDEAN" | "DOT_PRODUCT";
 type NamespaceInfo = {
   vectorCount: number;
   pendingVectorCount: number;
 };
+
+type DenseIndexInfo = {
+  dimension: number;
+  similarityFunction: SimilarityFunction;
+  embeddingModel: string;
+}
+
+type SparseIndexInfo = {
+  embeddingModel: string;
+}
 
 export type InfoResult = {
   vectorCount: number;
   pendingVectorCount: number;
   indexSize: number;
   dimension: number;
-  similarityFunction: "COSINE" | "EUCLIDEAN" | "DOT_PRODUCT";
+  similarityFunction: SimilarityFunction;
+  denseIndex?: DenseIndexInfo;
+  sparseIndex?: SparseIndexInfo;
   namespaces: Record<NamespaceTitle, NamespaceInfo>;
 };
 

--- a/src/commands/client/info/index.ts
+++ b/src/commands/client/info/index.ts
@@ -10,11 +10,11 @@ type NamespaceInfo = {
 type DenseIndexInfo = {
   dimension: number;
   similarityFunction: SimilarityFunction;
-  embeddingModel: string;
+  embeddingModel?: string;
 }
 
 type SparseIndexInfo = {
-  embeddingModel: string;
+  embeddingModel?: string;
 }
 
 export type InfoResult = {


### PR DESCRIPTION
The new response of the info endpoint is as below, we updated the types accordingly:

```json
{
  "vectorCount": 793,
  "pendingVectorCount": 0,
  "indexSize": 10797470,
  "dimension": 1024,
  "similarityFunction": "COSINE",
  "namespaces": {
    "ns": {
      "vectorCount": 0,
      "pendingVectorCount": 0
    }
  },
  "indexType": "DENSE",
  "denseIndex": {
    "dimension": 1024,
    "similarityFunction": "COSINE",
    "embeddingModel": "BGE_M3"
  },
  "sparseIndex": {
    "embeddingModel": "BM25"
  }
}
```