### PR TITLE
DX-1938: update signal parameter to accept function

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,7 +121,7 @@ jobs:
         working-directory: examples/cloudflare-workers
 
       - name: Deploy
-        run: wrangler publish
+        run: wrangler deploy
         working-directory: examples/cloudflare-workers
         env:
           CLOUDFLARE_API_TOKEN: ${{secrets.CLOUDFLARE_API_TOKEN}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/src/commands/client/info/index.ts
+++ b/src/commands/client/info/index.ts
@@ -11,11 +11,11 @@ type DenseIndexInfo = {
   dimension: number;
   similarityFunction: SimilarityFunction;
   embeddingModel?: string;
-}
+};
 
 type SparseIndexInfo = {
   embeddingModel?: string;
-}
+};
 
 export type InfoResult = {
   vectorCount: number;

--- a/src/http/index.test.ts
+++ b/src/http/index.test.ts
@@ -59,7 +59,6 @@ describe("Abort", () => {
   const SERVER_URL = `http://localhost:${MOCK_SERVER_PORT}`;
 
   test("should throw on request timeouts", async () => {
-
     const result: InfoResult = {
       vectorCount: 0,
       pendingVectorCount: 0,
@@ -67,11 +66,10 @@ describe("Abort", () => {
       dimension: 0,
       similarityFunction: "COSINE",
       namespaces: {},
-    }
+    };
 
     const server = serve({
       async fetch(request) {
-
         if (request.url.includes("info")) {
           return new Response(JSON.stringify({ result }), { status: 200 });
         }

--- a/src/platforms/cloudflare.ts
+++ b/src/platforms/cloudflare.ts
@@ -1,3 +1,4 @@
+import type { HttpClientConfig } from "@http";
 import { HttpClient, type RequesterConfig } from "@http";
 import * as core from "./../vector";
 
@@ -23,7 +24,7 @@ export type IndexConfig = {
    * The signal will allow aborting requests on the fly.
    * For more check: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
-  signal?: AbortSignal;
+  signal?: HttpClientConfig["signal"];
 
   /**
    * Enable telemetry to help us improve the SDK.

--- a/src/platforms/nodejs.ts
+++ b/src/platforms/nodejs.ts
@@ -1,3 +1,4 @@
+import type { HttpClientConfig } from "@http";
 import { HttpClient, type Requester, type RequesterConfig } from "@http";
 import * as core from "./../vector";
 import type { Dict } from "@commands/client/types";
@@ -24,7 +25,7 @@ export type IndexConfig = {
    * The signal will allow aborting requests on the fly.
    * For more check: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
    */
-  signal?: AbortSignal;
+  signal?: HttpClientConfig["signal"];
 
   /**
    * Enable telemetry to help us improve the SDK.


### PR DESCRIPTION
Currently, there is a signal parameter which accepts an AbortSignal but this has two limitations which make configuring request timeout not feasible:

If a request gets timeout, the signal.aborted field becomes true, and it stays true in subsequent requests as the object remains the same.
When we get a timeout, in the request method of HttpClient, a Response object is created with status 200. So the request method never throws an error. The response is simply null.
Did the following to fix the issue:

Made it possible to pass an AbortSignal creator function as signal.
When this is done, we simply throw the error which can be cought:

```ts
try {
  const result = await index.query( *** );
} catch (error) {
  if (error instanceof Error && error.name === "TimeoutError") {
    console.error("Timeout: It took more than 500 ms to get the result!");
  }
}
```

Equivalent change in redis-js https://github.com/upstash/redis-js/pull/1379